### PR TITLE
change `custom_url` of _imprint.html_ to ""

### DIFF
--- a/imprint.html
+++ b/imprint.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-custom_url: "/"
+custom_url: ""
 ---
 
 <div class="imprint">


### PR DESCRIPTION
The bug mentioned in Issue #58 should be fixed with this change of the value of `custom_url` from "/" to "" in _imprint.html_.