### PR TITLE
Remove job ads temporarily

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -13,7 +13,7 @@
                     </ul>
                 </div>
                 <div class="col-md-4">
-                    <a href="/jobs">Careers</a> |
+                    <!--<a href="/jobs">Careers</a> |-->
                     <a href="/imprint">Imprint</a>
                 </div>
                 <!--

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -59,7 +59,7 @@
                 biomedical R&amp;D.</div>
 
 
-            <p class="hiring"><a href="/jobs#jobs">We're hiring!</a></p>
+            <!--<p class="hiring"><a href="/jobs#jobs">We're hiring!</a></p>-->
             <!--<a href="#services" class="page-scroll btn btn-xl">Tell Me More</a>-->
         </div>
     </div>


### PR DESCRIPTION
The link to the job ads and the `Career` section in the footer are commented out and can be reused easily.